### PR TITLE
Pull Request: added option for no dynamic import paths and two minor adaptations

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,14 @@ A simple `graphql_config.yaml` file will look something like this:
       id: int
 ```
 
-#### Note: All options except `type_override` are required.
+#### Note: All options except `type_override` and `dynamic_import_path` are required.
 
 Run the command `flutter packages pub run graphql_to_dart` if you are using Flutter, otherwise simply `pub run graphql_to_dart`.
 
 You can find the generated models in the path you provided to `models_directory_path` argument in `graphql_config.yaml`.
+
+When you set `models_directory_path` outside of `lib/`, `import 'package:packagename/path/filename.dart';` is not applicable.
+Add option `dynamic_import_path: false` for `import 'filename.dart'`. 
 
 
 ### Milestones

--- a/lib/src/builders/type_builder.dart
+++ b/lib/src/builders/type_builder.dart
@@ -55,35 +55,35 @@ class TypeBuilder {
 
   _addToJson() {
     StringBuffer toJsonBuilder = StringBuffer();
-    toJsonBuilder.writeln("Map data = {};");
+    toJsonBuilder.writeln("Map _data = {};");
     localFields.forEach((field) {
       if (field.list == true) {
         if (field.type == "DateTime") {
           toJsonBuilder.writeln(
-              "data['${field.name}'] = List.generate(${field.name}?.length ?? 0, (index)=> ${field.name}[index].toString());");
+              "_data['${field.name}'] = List.generate(${field.name}?.length ?? 0, (index)=> ${field.name}[index].toString());");
         } else if (field.object == true) {
           toJsonBuilder.writeln(
-              "data['${field.name}'] = List.generate(${field.name}?.length ?? 0, (index)=> ${field.name}[index].toJson());");
+              "_data['${field.name}'] = List.generate(${field.name}?.length ?? 0, (index)=> ${field.name}[index].toJson());");
         } else {
-          toJsonBuilder.writeln("data['${field.name}'] = ${field.name};");
+          toJsonBuilder.writeln("_data['${field.name}'] = ${field.name};");
         }
       } else if (field.object == true) {
         toJsonBuilder
-            .writeln("data['${field.name}'] = ${field.name}?.toJson();");
+            .writeln("_data['${field.name}'] = ${field.name}?.toJson();");
       } else if (field.type == "DateTime") {
         toJsonBuilder
-            .writeln("data['${field.name}'] = ${field.name}?.toString();");
+            .writeln("_data['${field.name}'] = ${field.name}?.toString();");
       } else {
-        toJsonBuilder.writeln("data['${field.name}'] = ${field.name};");
+        toJsonBuilder.writeln("_data['${field.name}'] = ${field.name};");
       }
     });
     stringBuffer.writeln();
-    toJsonBuilder.writeln("return data;");
+    toJsonBuilder.writeln("return _data;");
     stringBuffer.writeln();
     stringBuffer
         .write(_wrapWith(toJsonBuilder.toString(), "Map toJson(){", "}"));
   }
-
+  
   _addFromJson() {
     StringBuffer fromJsonBuilder = StringBuffer();
     localFields.forEach((field) {

--- a/lib/src/builders/type_builder.dart
+++ b/lib/src/builders/type_builder.dart
@@ -138,7 +138,6 @@ ${field.object == true ? "List.generate(json['${field.name}'].length, (index)=> 
 
   _typeOrdering(Type type, String fieldName) {
     bool list = false;
-    String typeName;
     LocalField localField;
     if (type.kind == "NON_NULL") {
       type = type.ofType;
@@ -151,17 +150,15 @@ ${field.object == true ? "List.generate(json['${field.name}'].length, (index)=> 
       type = type.ofType;
     }
     if (type.kind == scalar) {
-      typeName = type.name.toLowerCase();
       localField = LocalField(
           name: fieldName,
           list: list,
-          type: TypeConverters().nonObjectTypes[typeName],
+          type: TypeConverters().nonObjectTypes[type.name.toLowerCase()],
           object: false);
       localFields.add(localField);
     } else {
-      typeName = type.name;
       localField =
-          LocalField(name: fieldName, list: list, type: typeName, object: true);
+          LocalField(name: fieldName, list: list, type: type.name, object: true);
       localFields.add(localField);
     }
     stringBuffer.writeln(localField.toDeclarationStatement());

--- a/lib/src/builders/type_builder.dart
+++ b/lib/src/builders/type_builder.dart
@@ -35,9 +35,16 @@ class TypeBuilder {
     StringBuffer importBuffer = StringBuffer();
     localFields.unique<String>((field) => field.type).forEach((field) {
       if (field.object == true) {
+        if(config.dynamicImportPath){
         importBuffer.writeln(
             "import 'package:${config.packageName}/${config.modelsDirectoryPath.replaceAll(r"lib/", "")}/${pascalToSnake(field.type)}.dart';"
                 .replaceAll(r"//", r"/"));
+      }
+        else{
+          importBuffer.writeln(
+            "import '${pascalToSnake(field.type)}.dart';"
+                .replaceAll(r"//", r"/"));
+        }
       }
     });
     String current = stringBuffer.toString();

--- a/lib/src/constants/type_converters.dart
+++ b/lib/src/constants/type_converters.dart
@@ -17,7 +17,7 @@ class TypeConverters {
 
   void overrideTypes(Map newTypes) {
     newTypes?.forEach((key, value) {
-      nonObjectTypes[key] = value;
+      nonObjectTypes[key.toString().toLowerCase()] = value;
     });
   }
 }

--- a/lib/src/models/config.dart
+++ b/lib/src/models/config.dart
@@ -10,6 +10,7 @@ class Config {
 //  String subscriptionsFilePath;
   String packageName;
   String modelsDirectoryPath;
+  bool dynamicImportPath;
   YamlMap typeOverride;
   Config({this.modelsDirectoryPath});
   Config.fromJson(Map map) {
@@ -18,7 +19,8 @@ class Config {
 //    mutationsFilePath = map['mutations_file_path']?.toString();
 //    subscriptionsFilePath = map['subscriptions_file_path']?.toString();
     modelsDirectoryPath = map['models_directory_path']?.toString();
-    ;
+    dynamicImportPath = map['dynamic_import_path']?.toString() == 'true' ? true : false;
+
     packageName = map['package_name'];
     typeOverride = map['type_override'];
   }

--- a/lib/src/models/config.dart
+++ b/lib/src/models/config.dart
@@ -19,7 +19,7 @@ class Config {
 //    mutationsFilePath = map['mutations_file_path']?.toString();
 //    subscriptionsFilePath = map['subscriptions_file_path']?.toString();
     modelsDirectoryPath = map['models_directory_path']?.toString();
-    dynamicImportPath = map['dynamic_import_path']?.toString() == 'true' ? true : false;
+    dynamicImportPath = map['dynamic_import_path']?.toString() == 'false' ? false : true;
 
     packageName = map['package_name'];
     typeOverride = map['type_override'];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: graphql_to_dart
 description: A simple dart package to generate complete Dart models from a GraphQL endpoint by leveraging GraphQL introspection API.
-version: 1.0.1
+version: 1.1.0
 homepage: https://github.com/vikram25897/graphql_to_dart
 environment:
   sdk: '>=2.6.0 <3.0.0'


### PR DESCRIPTION
Hi, 
thank you so much for this repo, it's the nearest thing to what we want to achieve [[1]](https://stackoverflow.com/questions/62590497/how-to-generate-dart-from-graphql-graphql-to-dart-generator/).

I am committing this PR mainly because of three things:
- making dynamic import package paths optional, when you need them generated outside of `lib/`
- improvement of `type_override` through `TypeConverters.overrideTypes()`, so its keys don't need to be explicitly added in lower case
- avoiding name conflicts with GraphQL schema in `TypeBuilder._addToJson()`, if there are fields also called `data`

As well I hope the added explanation in `README.md` suits this.

It would be great if this could be merged and published, it would mean a lot to me, since this is my first PR @github :)

1: https://stackoverflow.com/questions/62590497/how-to-generate-dart-from-graphql-graphql-to-dart-generator/